### PR TITLE
Add content script and host permissions to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,5 +11,13 @@
       "128": "icons/128.png"
     }
   },
-  "permissions": []
+  "permissions": [],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ],
+  "host_permissions": ["<all_urls>"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,5 @@
       "run_at": "document_end"
     }
   ],
-  "host_permissions": ["<all_urls>"]
+  "host_permissions": ["https://*/*"]
 }


### PR DESCRIPTION
## Summary
- inject `content.js` on all pages at document end
- allow extension access to all URLs

## Testing
- `npm test` (fails: Missing script)
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_688de3055c9c8327a30f997f98a8cf73